### PR TITLE
Add babel-plugin-transform-runtime

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,3 +1,4 @@
 {
-  "presets": ["es2015", "stage-0"]
+  "presets": ["es2015", "stage-0"],
+  "plugins": ["transform-runtime"]
 }

--- a/index.js
+++ b/index.js
@@ -5,6 +5,5 @@
 // require('module').Module._initPaths();
 
 require('babel-register');
-require('babel-polyfill');
 
 require('./test/terminal');

--- a/package.json
+++ b/package.json
@@ -34,7 +34,6 @@
   "license": "MIT",
   "dependencies": {
     "alchemy-api": "1.3.2",
-    "babel-polyfill": "6.9.0",
     "bayes": "0.0.6",
     "chrono-node": "1.2.3",
     "cld": "2.4.5",
@@ -51,6 +50,7 @@
   "devDependencies": {
     "babel-cli": "^6.10.1",
     "babel-core": "^6.9.0",
+    "babel-plugin-transform-runtime": "^6.12.0",
     "babel-preset-es2015": "^6.9.0",
     "babel-preset-stage-0": "^6.5.0",
     "babel-register": "^6.9.0",


### PR DESCRIPTION
Thx for this great module.

There is a small issue and I'm not sure if this is intended. If I just install the module from npm and execute it in node without using babel, it throws 

```
ReferenceError: regeneratorRuntime is not defined
    at /node_modules/ava-ia/lib/helpers/factoryActions.js:10:31
    at Object.<anonymous> (/node_modules/ava-ia/lib/helpers/factoryActions.js:36:2)
    at Module._compile (module.js:541:32)
    at Object.Module._extensions..js (module.js:550:10)
    at Module.load (module.js:458:32)
    at tryModuleLoad (module.js:417:12)
    at Function.Module._load (module.js:409:3)
    at Module.require (module.js:468:17)
    at require (internal/module.js:20:19)
    at Object.<anonymous> (/node_modules/ava-ia/lib/helpers/index.js:43:23)
    at Module._compile (module.js:541:32)
    at Object.Module._extensions..js (module.js:550:10)
    at Module.load (module.js:458:32)
    at tryModuleLoad (module.js:417:12)
    at Function.Module._load (module.js:409:3)
    at Module.require (module.js:468:17)

```

This is because the compiled code requires some global variables, like `regeneratorRuntime` which you need to polyfill if you want to use the module without babel.

I've added the babel-plugin-transform-runtime which translates these global dependencies into local requires. In this case, you don't need to polyfill the runtime environment anymore (like you did in the `index.js`).

You'll need to build the code again of course. I haven't done that in this PR because I did not want to pollute it with generated code.