### PR TITLE
bump cld version to fix windows build.

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "alchemy-api": "1.3.2",
     "bayes": "0.0.6",
     "chrono-node": "1.2.3",
-    "cld": "2.4.5",
+    "cld": "2.4.7",
     "google-translate-api": "2.1.1",
     "lowdb": "0.13.0",
     "moment": "2.13.0",


### PR DESCRIPTION
node-cld had [troubles](https://github.com/dachev/node-cld/issues/32) compiling on windows. thanks to @paulcbetts and @dachev for fixing it! 
